### PR TITLE
Updated steps to set MAC address for VF interfaces

### DIFF
--- a/deployment/deploymentupf.rst
+++ b/deployment/deploymentupf.rst
@@ -79,6 +79,29 @@ step 1: Create VF devices and bind them to the vfio-pci driver
 
     ls -l /sys/class/net/ens801f0/device/virtfn*
 
+- Make sure all the VF devices contains valid MAC address(not all zero's),
+
+  .. code-block::
+
+    ip link show ens801f0
+
+  If the MAC shown for VF's are all zero's then retrieve the MAC using the PCI obtained above as follows,
+
+  .. code-block::
+
+    cat /sys/bus/pci/devices/0000\:b1\:01.0/net/ens801f0v0/address
+    00:11:22:33:44:50
+
+    cat /sys/bus/pci/devices/0000\:b1\:01.1/net/ens801f0v1/address
+    00:11:22:33:44:51
+
+  Set the above retrieved MAC address for the VF's using below command,
+
+  .. code-block::
+
+    ip link set ens801f0 vf 0 mac 00:11:22:33:44:50
+    ip link set ens801f0 vf 1 mac 00:11:22:33:44:51
+
 - Bind the VF devices to the vfio-pci driver as follows,
 
   .. code-block::

--- a/deployment/deploymentupf.rst
+++ b/deployment/deploymentupf.rst
@@ -79,13 +79,13 @@ step 1: Create VF devices and bind them to the vfio-pci driver
 
     ls -l /sys/class/net/ens801f0/device/virtfn*
 
-- Make sure all the VF devices contains valid MAC address(not all zero's),
+- Make sure all VF devices contain a valid MAC address (not all zero's),
 
   .. code-block::
 
     ip link show ens801f0
 
-  If the MAC shown for VF's are all zero's then retrieve the MAC using the PCI obtained above as follows,
+  If the MAC shown for the VF's are all zero's, then retrieve the MAC using the PCI obtained above, as follows,
 
   .. code-block::
 
@@ -95,7 +95,7 @@ step 1: Create VF devices and bind them to the vfio-pci driver
     cat /sys/bus/pci/devices/0000\:b1\:01.1/net/ens801f0v1/address
     00:11:22:33:44:51
 
-  Set the above retrieved MAC address for the VF's using below command,
+  Then, set the VF's MAC address using the value obtained above
 
   .. code-block::
 

--- a/release/1.1.rst
+++ b/release/1.1.rst
@@ -58,7 +58,7 @@ integration in Aether.
 multiple UEs and gNodeBs and performing both control plane and dataplane tests, which assist
 greatly in quick development of new 5G-SA features. In addition to a dev-test tool, it can also
 be used by QA teams to run automated tests for the 5G core network. Please refer to
-`gNB Sim documentation <https://github.com/omec-project/gnbsim#readme>`_ for more details.
+`gNB Sim documentation <https://github.com/omec-project/gnbsim/blob/main/README.md>`_ for more details.
 Support for Service Request and AN release procedures are added in this release.
 
 **Stability and Reliability**: We fixed a couple of stability issues seen in Aether deployments.


### PR DESCRIPTION
When enabling VF instances sometime valid MAC address not set for these interfaces. So updated the procedure to ensure the devices are set to valid MAC before deploy UPF in DPDK mode